### PR TITLE
Update _load_peer.py

### DIFF
--- a/gmspy/_load_peer.py
+++ b/gmspy/_load_peer.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import re
-import tkinter as tk
 import numpy as np
-from tkinter import filedialog
 from pathlib import Path
 from collections import namedtuple
 from typing import Union, NamedTuple
@@ -38,6 +36,8 @@ def loadPEER(filename: Union[str, Path, None] = None, plot: bool = False) -> Nam
     See .. _collections.namedtuple: https://docs.python.org/3/library/collections.html#collections.namedtuple.
     """
     if filename is None:
+        import tkinter as tk
+        from tkinter import filedialog
         root = tk.Tk()
         root.withdraw()
         root.call("wm", "attributes", ".", "-topmost", True)


### PR DESCRIPTION
Currently, tkinter is imported at the module level, which can lead to ModuleNotFoundError: No module named '_tkinter' in environments where GUI support is not available or needed — such as headless servers or cloud platforms like Render.

Since tkinter is only needed when calling loadPEER(), it would be more robust to move the import tkinter as tk statement inside the loadPEER() function. This way, users who don’t require the PEER data loading functionality — or are running in non-GUI environments — can still use the rest of the library without encountering import-time errors.